### PR TITLE
feat: add FastAPI task manager service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# codix
+# Gestionnaire de tâches FastAPI
+
+Cette application fournit une API REST pour gérer des tâches avec FastAPI et SQLite.
+
+## Installation locale
+
+1. Créez et activez un environnement virtuel Python.
+2. Installez les dépendances :
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Lancez l'application avec Uvicorn :
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+L'API est accessible sur `http://127.0.0.1:8000`. La documentation interactive Swagger est disponible sur `http://127.0.0.1:8000/docs`.
+
+## Lancement avec Docker
+
+1. Construisez l'image :
+
+   ```bash
+   docker build -t gestionnaire-taches .
+   ```
+
+2. Démarrez le conteneur :
+
+   ```bash
+   docker run -p 8000:8000 gestionnaire-taches
+   ```
+
+L'API sera accessible sur `http://127.0.0.1:8000`.
+
+## Exemples d'appels API
+
+### Créer une tâche
+
+```bash
+curl -X POST "http://127.0.0.1:8000/tasks" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Écrire la documentation",
+    "description": "Compléter le README",
+    "status": "à faire",
+    "date_limite": "2024-12-31"
+  }'
+```
+
+### Lister les tâches
+
+```bash
+curl http://127.0.0.1:8000/tasks
+```
+
+### Récupérer une tâche
+
+```bash
+curl http://127.0.0.1:8000/tasks/1
+```
+
+### Mettre à jour une tâche
+
+```bash
+curl -X PUT "http://127.0.0.1:8000/tasks/1" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "en cours"
+  }'
+```
+
+### Supprimer une tâche
+
+```bash
+curl -X DELETE http://127.0.0.1:8000/tasks/1
+```
+
+## Tests
+
+Lancez les tests avec :
+
+```bash
+pytest
+```

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,42 @@
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+def get_tasks(db: Session) -> List[models.Task]:
+    return db.query(models.Task).all()
+
+
+def get_task(db: Session, task_id: int):
+    return db.query(models.Task).filter(models.Task.id == task_id).first()
+
+
+def create_task(db: Session, task: schemas.TaskCreate) -> models.Task:
+    db_task = models.Task(
+        title=task.title,
+        description=task.description,
+        status=task.status,
+        due_date=task.due_date,
+    )
+    db.add(db_task)
+    db.commit()
+    db.refresh(db_task)
+    return db_task
+
+
+def update_task(
+    db: Session, task_db: models.Task, task_update: schemas.TaskUpdate
+) -> models.Task:
+    for field, value in task_update.dict(exclude_unset=True).items():
+        setattr(task_db, field, value)
+    db.add(task_db)
+    db.commit()
+    db.refresh(task_db)
+    return task_db
+
+
+def delete_task(db: Session, task_db: models.Task) -> None:
+    db.delete(task_db)
+    db.commit()

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./tasks.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,50 @@
+from fastapi import Depends, FastAPI, HTTPException, status
+from sqlalchemy.orm import Session
+
+from . import crud, models, schemas
+from .database import Base, engine, get_db
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Gestionnaire de tâches", description="API REST pour gérer des tâches")
+
+
+@app.get("/tasks", response_model=list[schemas.Task])
+def read_tasks(db: Session = Depends(get_db)):
+    return crud.get_tasks(db)
+
+
+@app.post(
+    "/tasks",
+    response_model=schemas.Task,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_new_task(task: schemas.TaskCreate, db: Session = Depends(get_db)):
+    return crud.create_task(db, task)
+
+
+@app.get("/tasks/{task_id}", response_model=schemas.Task)
+def read_task(task_id: int, db: Session = Depends(get_db)):
+    task = crud.get_task(db, task_id)
+    if not task:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tâche introuvable")
+    return task
+
+
+@app.put("/tasks/{task_id}", response_model=schemas.Task)
+def update_existing_task(
+    task_id: int, task_update: schemas.TaskUpdate, db: Session = Depends(get_db)
+):
+    task_db = crud.get_task(db, task_id)
+    if not task_db:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tâche introuvable")
+    return crud.update_task(db, task_db, task_update)
+
+
+@app.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_existing_task(task_id: int, db: Session = Depends(get_db)):
+    task_db = crud.get_task(db, task_id)
+    if not task_db:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tâche introuvable")
+    crud.delete_task(db, task_db)
+    return None

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Date, Integer, String
+
+from .database import Base
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    status = Column(String, nullable=False, default="à faire")
+    due_date = Column(Date, nullable=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,44 @@
+from datetime import date
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskStatus(str, Enum):
+    todo = "à faire"
+    in_progress = "en cours"
+    done = "terminé"
+
+
+class TaskBase(BaseModel):
+    title: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    status: TaskStatus = TaskStatus.todo
+    due_date: Optional[date] = Field(None, alias="date_limite")
+
+    class Config:
+        use_enum_values = True
+        allow_population_by_field_name = True
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = Field(None, min_length=1)
+    description: Optional[str] = None
+    status: Optional[TaskStatus] = None
+    due_date: Optional[date] = Field(None, alias="date_limite")
+
+    class Config:
+        use_enum_values = True
+        allow_population_by_field_name = True
+
+
+class Task(TaskBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+sqlalchemy==2.0.30
+pydantic==1.10.13
+pytest==8.2.2
+httpx==0.27.0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,96 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_tasks.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+
+def test_create_task():
+    response = client.post(
+        "/tasks",
+        json={
+            "title": "Nouvelle tâche",
+            "description": "Description",
+            "status": "à faire",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Nouvelle tâche"
+    assert data["status"] == "à faire"
+
+
+def test_read_tasks():
+    response = client.get("/tasks")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+
+def test_update_task():
+    response = client.post(
+        "/tasks",
+        json={
+            "title": "Tâche à mettre à jour",
+            "status": "à faire",
+        },
+    )
+    task_id = response.json()["id"]
+
+    update_response = client.put(
+        f"/tasks/{task_id}",
+        json={
+            "title": "Tâche mise à jour",
+            "status": "en cours",
+            "date_limite": date.today().isoformat(),
+        },
+    )
+    assert update_response.status_code == 200
+    updated_task = update_response.json()
+    assert updated_task["title"] == "Tâche mise à jour"
+    assert updated_task["status"] == "en cours"
+    assert updated_task["date_limite"] == date.today().isoformat()
+
+
+def test_delete_task():
+    response = client.post(
+        "/tasks",
+        json={
+            "title": "Tâche à supprimer",
+            "status": "à faire",
+        },
+    )
+    task_id = response.json()["id"]
+
+    delete_response = client.delete(f"/tasks/{task_id}")
+    assert delete_response.status_code == 204
+
+    get_response = client.get(f"/tasks/{task_id}")
+    assert get_response.status_code == 404


### PR DESCRIPTION
## Summary
- implement a FastAPI application with CRUD endpoints for managing tasks backed by SQLite and SQLAlchemy
- define Pydantic schemas, database utilities, and CRUD helpers for task operations
- add pytest-based API tests plus Dockerfile, requirements, and documentation for local and containerized usage

## Testing
- ⚠️ `pytest` *(fails: environment lacks FastAPI dependency because packages cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc5d91ffc8333bb1bebfd429e13c2